### PR TITLE
Remove IPs from active SSH notification.

### DIFF
--- a/quickconfig/002-ipaddr.sh
+++ b/quickconfig/002-ipaddr.sh
@@ -15,7 +15,7 @@ SSH_OPTION=$(grep -Eo '\<ssh=[^ ]+' /proc/cmdline || true)
 PWD_OPTION=$(grep -Eo '\<passwd=[^ ]+' /proc/cmdline || true)
 
 if [ -n "${SSHD_PID:-}" ] ; then
-  LINE+="print_line 'You can connect with SSH to: ${IPADDR:-} ${IPADDR6:-} ${AVAHI_INFO:-}';"
+  LINE+="print_line 'You can connect with SSH to the IP addresses listed below.';"
 fi
 
 USER=$(getent passwd 1000 | cut -d: -f1)


### PR DESCRIPTION
with IPv6 it doesn't look pretty anymore and the ip addresses are listed in "Network information" anyhow.

```
 ┌────────────────────────────────────────────────────────────┐
 │ Welcome to grml-quickconfig                                │
 │ Press a highlighted key to perform an action, or press     │
 │ Return or q to go back to the shell, or r to refresh.      │
 ├────────────────────────────────────────────────────────────┤
 │ You can connect with SSH to: 10.10.2.183 XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX                      │
 │ The password for user root/grml is: GRMLGRML               │
 │ Network information:                                       │
 │ -> Hostname:   grml-sid.local                              │
 │ -> IP address: 10.10.2.183                                 │
 │ -> IP address: XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX     │
 ├────────────────────────────────────────────────────────────┤
 │ Set keyboard layout (grml-lang): de at ch es us            │
 │ Configure network (grml-network)                           │
 │ -> Configure ethernet card directly (netcardconfig)        │
 ├────────────────────────────────────────────────────────────┤
 │ Show information about Grml (grml-info)                    │
 │ Start x (grml-x)                                           │
 │ Install Debian to hard disk (grml-debootstrap)             │
 └────────────────────────────────────────────────────────────┘

```

And yeah, i used the word "IP" even though "Hostname" *might* be resolved via avahi-dreck but as that doesn't even know how to read the the search domains from resolv.conf i think that is pretty useless at the current state to rely on. and as a hostname might be pre-defined in the network (e.g. $department-202.$(dnsdomainname) for 10.80.93.202/24 as a default) the "hostname" dhcpcd sends won't even matter to the dns in the network 🙈
But enough about that, this can/will go later into an issue/mr.